### PR TITLE
Fix displaying of the missing source image text in sprite editor

### DIFF
--- a/include/widgets/sprite_scene.h
+++ b/include/widgets/sprite_scene.h
@@ -67,6 +67,9 @@ private:
       direction_items;                /**< Each direction item in the scene,
                                        * ordered as in the model. */
 
+  QGraphicsTextItem* missing_text;    /**< Text displayed when the
+                                       * source image is missing. */
+
 };
 
 }

--- a/src/widgets/sprite_scene.cpp
+++ b/src/widgets/sprite_scene.cpp
@@ -73,6 +73,8 @@ SpriteScene::SpriteScene(SpriteModel& model, QObject* parent) :
   QGraphicsScene(parent),
   model(model) {
 
+  missing_text = addText("");
+  missing_text->setZValue(10);
   rebuild();
 
   // Synchronize the scene selection with the sprite selection model.
@@ -192,12 +194,14 @@ void SpriteScene::update_image() {
 
   const QImage& image = model.get_animation_image(animation_name);
 
+  missing_text->setVisible(false);
   if (image.isNull()) {
     QString src_image = model.get_animation_source_image(animation_name);
     if (!src_image.isEmpty()) {
       QString path = get_quest().get_sprite_image_path(src_image);
       path = path.right(path.length() - get_quest().get_data_path().length() - 1);
-      addText(tr("Missing source image '%1'").arg(path));
+      missing_text->setPlainText(tr("Missing source image '%1'").arg(path));
+      missing_text->setVisible(true);
     }
   }
 


### PR DESCRIPTION
Closes #191.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/christopho/solarus-quest-editor/212)
<!-- Reviewable:end -->
