### PR TITLE
Open quest file dialog

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,6 +134,7 @@ set(solarus_quest_editor_SOURCES
   include/widgets/find_text_dialog.h
   include/widgets/get_animation_name_dialog.h
   include/widgets/gui_tools.h
+  include/widgets/line_edit.h
   include/widgets/lua_syntax_highlighter.h
   include/widgets/map_editor.h
   include/widgets/map_view.h
@@ -143,6 +144,7 @@ set(solarus_quest_editor_SOURCES
   include/widgets/music_chooser.h
   include/widgets/new_resource_element_dialog.h
   include/widgets/new_string_dialog.h
+  include/widgets/open_quest_file_dialog.h
   include/widgets/pair_spin_box.h
   include/widgets/pan_tool.h
   include/widgets/plain_text_edit.h
@@ -254,6 +256,7 @@ set(solarus_quest_editor_SOURCES
   src/widgets/music_chooser.cpp
   src/widgets/new_resource_element_dialog.cpp
   src/widgets/new_string_dialog.cpp
+  src/widgets/open_quest_file_dialog.cpp
   src/widgets/pair_spin_box.cpp
   src/widgets/pan_tool.cpp
   src/widgets/quest_properties_editor.cpp
@@ -332,6 +335,7 @@ set(solarus_quest_editor_FORMS
   src/widgets/map_editor.ui
   src/widgets/new_resource_element_dialog.ui
   src/widgets/new_string_dialog.ui
+  src/widgets/open_quest_file_dialog.ui
   src/widgets/quest_properties_editor.ui
   src/widgets/settings_dialog.ui
   src/widgets/sprite_editor.ui

--- a/include/editor_settings.h
+++ b/include/editor_settings.h
@@ -38,6 +38,7 @@ public:
   static const QString no_audio;
   static const QString video_acceleration;
   static const QString quest_size;
+  static const QString open_quest_file_history;
 
   // Console keys.
   static const QString console_history;
@@ -91,6 +92,7 @@ public:
   QStringList get_value_string_list(const QString& key);
   QSize get_value_size(const QString& key);
   QColor get_value_color(const QString& key);
+  QMap<QString, QVariant> get_value_map(const QString& key);
 
   QVariant get_default(const QString& key);
   bool get_default_bool(const QString& key);
@@ -99,6 +101,7 @@ public:
   QString get_default_string(const QString& key);
   QSize get_default_size(const QString& key);
   QColor get_default_color(const QString& key);
+  QMap<QString, QVariant> get_default_map(const QString& key);
 
   void set_value(const QString& key, const QVariant& value);
   void set_value_color(const QString& key, const QColor& value);

--- a/include/quest.h
+++ b/include/quest.h
@@ -84,6 +84,8 @@ public:
   QString get_tileset_tiles_image_path(const QString& tileset_id) const;
   QString get_tileset_entities_image_path(const QString& tileset_id) const;
 
+  QIcon get_file_icon(const QString& file_path) const;
+
   // Check path properties.
   static bool is_valid_file_name(const QString& file_name);
   static void check_valid_file_name(const QString& file_name);

--- a/include/quest_files_model.h
+++ b/include/quest_files_model.h
@@ -130,7 +130,6 @@ private:
     void rebuild_index_cache();
   };
 
-  QIcon get_quest_file_icon(const QModelIndex& index) const;
   QString get_quest_file_tooltip(const QModelIndex& index) const;
   bool is_quest_data_index(const QModelIndex& index) const;
 

--- a/include/widgets/line_edit.h
+++ b/include/widgets/line_edit.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2014-2016 Christopho, Solarus - http://www.solarus-games.org
+ *
+ * Solarus Quest Editor is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Solarus Quest Editor is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+#ifndef SOLARUSEDITOR_LINE_EDIT_H
+#define SOLARUSEDITOR_LINE_EDIT_H
+
+#include <QLineEdit>
+
+namespace SolarusEditor {
+
+/**
+ * @brief A line editor that sends focus_in() and focus_lost() signals.
+ */
+class LineEdit : public QLineEdit {
+  Q_OBJECT
+
+public:
+
+  inline LineEdit(QWidget* parent = nullptr) :
+    QLineEdit(parent) {
+  }
+
+signals:
+
+  void focus_in(QFocusEvent* event);
+  void focus_out(QFocusEvent* event);
+
+protected:
+
+  inline virtual void focusInEvent(QFocusEvent* event) override {
+    emit focus_in(event);
+    QLineEdit::focusInEvent(event);
+  }
+
+  inline virtual void focusOutEvent(QFocusEvent* event) override {
+    emit focus_out(event);
+    QLineEdit::focusOutEvent(event);
+  }
+
+};
+
+}
+
+#endif

--- a/include/widgets/main_window.h
+++ b/include/widgets/main_window.h
@@ -17,6 +17,7 @@
 #ifndef SOLARUSEDITOR_MAIN_WINDOW_H
 #define SOLARUSEDITOR_MAIN_WINDOW_H
 
+#include "widgets/open_quest_file_dialog.h"
 #include "widgets/settings_dialog.h"
 #include "quest.h"
 #include "ui_main_window.h"
@@ -62,6 +63,7 @@ private slots:
   void on_action_save_all_triggered();
   void on_action_close_triggered();
   void on_action_close_all_triggered();
+  void on_action_open_quest_file_triggered();
   void on_action_open_quest_properties_triggered();
   void on_action_exit_triggered();
   void on_action_cut_triggered();
@@ -177,6 +179,8 @@ private:
       common_actions;             /**< Actions available to all editors. */
 
   SettingsDialog settings_dialog; /**< The settings dialog. */
+  OpenQuestFileDialog
+      open_quest_file_dialog;     /**< The open quest file dialog. */
 
 };
 

--- a/include/widgets/open_quest_file_dialog.h
+++ b/include/widgets/open_quest_file_dialog.h
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2014-2016 Christopho, Solarus - http://www.solarus-games.org
+ *
+ * Solarus Quest Editor is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Solarus Quest Editor is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+#ifndef SOLARUSEDITOR_OPEN_QUEST_FILE_DIALOG_H
+#define SOLARUSEDITOR_OPEN_QUEST_FILE_DIALOG_H
+
+#include "ui_open_quest_file_dialog.h"
+#include <QStyledItemDelegate>
+#include <QWidget>
+
+namespace SolarusEditor {
+
+class Quest;
+
+/**
+ * @brief A dialog to open a quest file.
+ */
+class OpenQuestFileDialog : public QDialog {
+  Q_OBJECT
+
+public:
+
+  OpenQuestFileDialog(QWidget* parent = nullptr);
+
+public slots:
+
+  void open_quest_file(Quest* quest, const QPoint& position);
+  virtual void done(int) override;
+
+protected:
+
+  virtual void keyPressEvent(QKeyEvent* event) override;
+
+private slots:
+
+  void update_list();
+
+signals:
+
+  void open_file_requested(Quest& quest, const QString& file_path);
+
+private:
+
+  void append_item(const QString& full_path);
+
+  void update_item(QListWidgetItem* item, int& top);
+  void update_display(
+    QListWidgetItem* item, const QRegularExpressionMatch& match);
+
+  void select_visible_item(bool to_up = false);
+
+private:
+
+  static const int FULL_PATH_ROLE = Qt::UserRole;
+  static const int SHORT_PATH_ROLE = Qt::UserRole + 1;
+
+  static const QString style_sheet; /**< The dialog style sheet. */
+
+  Ui::OpenQuestFileDialog ui;       /**< The widgets. */
+  Quest* quest;                     /**< The quest. */
+  QMap<QString, QVariant> history;  /**< History of text to path association. */
+
+  /**
+   * @brief The item delegate for the list widget.
+   *
+   * This class is used to allow rich text in the list view.
+   */
+  class  ItemDelegate: public QStyledItemDelegate {
+
+  public:
+
+    ItemDelegate(QObject* parent = nullptr);
+
+    virtual void paint(
+      QPainter* painter, const QStyleOptionViewItem& option,
+      const QModelIndex& index) const override;
+    virtual QSize sizeHint(
+      const QStyleOptionViewItem& option,
+      const QModelIndex& index) const override;
+
+  };
+
+};
+
+}
+
+#endif

--- a/include/widgets/open_quest_file_dialog.h
+++ b/include/widgets/open_quest_file_dialog.h
@@ -19,7 +19,7 @@
 
 #include "ui_open_quest_file_dialog.h"
 #include <QStyledItemDelegate>
-#include <QWidget>
+#include <QDialog>
 
 namespace SolarusEditor {
 

--- a/src/editor_settings.cpp
+++ b/src/editor_settings.cpp
@@ -31,6 +31,8 @@ const QString EditorSettings::save_files_before_running = "save_files_before_run
 const QString EditorSettings::no_audio = "no_audio";
 const QString EditorSettings::video_acceleration = "video_acceleration";
 const QString EditorSettings::quest_size = "quest_size";
+const QString EditorSettings::open_quest_file_history =
+  "open_quest_file_history";
 
 // Console keys.
 const QString EditorSettings::console_history = "console_history";
@@ -95,6 +97,7 @@ QMap<QString, QVariant> EditorSettings::default_values = {
   { EditorSettings::no_audio, false },
   { EditorSettings::video_acceleration, true },
   { EditorSettings::quest_size, QSize() },
+  { EditorSettings::open_quest_file_history, QMap<QString, QVariant>() },
 
   // Console.
   { EditorSettings::console_history, QStringList() },
@@ -249,6 +252,16 @@ QColor EditorSettings::get_value_color(const QString& key) {
 }
 
 /**
+ * @brief Returns a settings map value.
+ * @param key The key of the setting.
+ * @return The map value of the setting.
+ */
+QMap<QString, QVariant> EditorSettings::get_value_map(const QString& key) {
+
+  return get_value(key).toMap();
+}
+
+/**
  * @brief Returns a settings default value.
  * @param key The key of the setting.
  * @return The default value of the setting.
@@ -319,6 +332,16 @@ QSize EditorSettings::get_default_size(const QString& key) {
 QColor EditorSettings::get_default_color(const QString& key) {
 
   return QColor(get_default(key).toString());
+}
+
+/**
+ * @brief Returns a settings default map value.
+ * @param key The key of the setting.
+ * @return The default map value of the setting.
+ */
+QMap<QString, QVariant> EditorSettings::get_default_map(const QString& key) {
+
+  return get_default(key).toMap();
 }
 
 /**

--- a/src/quest.cpp
+++ b/src/quest.cpp
@@ -574,6 +574,65 @@ QString Quest::get_tileset_entities_image_path(
 }
 
 /**
+ * @brief Returns an appropriate icon for the specified quest file.
+ * @param file_path Path of the file.
+ * @return An appropriate icon name to represent this file.
+ */
+QIcon Quest::get_file_icon(const QString& file_path) const {
+
+  QString icon_file_name;  // Relative to the icons directory.
+  ResourceType resource_type;
+  QString element_id;
+
+  // Quest data directory or quest properties.
+  if (is_data_path(file_path) || is_properties_path(file_path)) {
+    icon_file_name = "icon_solarus.png";
+  }
+
+  // Resource element (possibly a directory for languages).
+  else if (is_resource_element(file_path, resource_type, element_id)) {
+
+    QString resource_type_name = get_resources().get_lua_name(resource_type);
+    if (exists(get_resource_element_path(resource_type, element_id))) {
+      // Resource declared and present on the filesystem.
+      icon_file_name = "icon_resource_" + resource_type_name + ".png";
+    }
+    else {
+      // Resource declared but whose file is missing.
+      icon_file_name = "icon_resource_" + resource_type_name + "_missing.png";
+    }
+  }
+
+  // Directory icon.
+  else if (is_dir(file_path)) {
+
+    if (is_resource_path(file_path, resource_type)) {
+      QString resource_type_name = get_resources().get_lua_name(resource_type);
+      icon_file_name = "icon_folder_open_" + resource_type_name + ".png";
+    }
+    else {
+      icon_file_name = "icon_folder_open.png";
+    }
+  }
+
+  // Lua script icon.
+  else if (is_script(file_path)) {
+    icon_file_name = "icon_script.png";
+  }
+
+  // Generic icon for a file not known by the quest.
+  else {
+    icon_file_name = "icon_file_unknown.png";
+  }
+
+  if (icon_file_name.isEmpty()) {
+    return QIcon();
+  }
+
+  return QIcon(":/images/" + icon_file_name);
+}
+
+/**
  * @brief Returns whether a path is the quest properties file quest.dat.
  * @param path The path to test.
  * @return @c true if this is the quest properties file.

--- a/src/quest_files_model.cpp
+++ b/src/quest_files_model.cpp
@@ -438,7 +438,7 @@ QVariant QuestFilesModel::data(const QModelIndex& index, int role) const {
   case Qt::DecorationRole:
     // Icon.
     if (index.column() == FILE_COLUMN) {
-      return get_quest_file_icon(index);
+      return quest.get_file_icon(path);
     }
     return QVariant();  // No icon in other columns.
 
@@ -500,66 +500,6 @@ bool QuestFilesModel::setData(
     ex.print_message();
     return false;
   }
-}
-
-/**
- * @brief Returns an appropriate icon for the specified quest file.
- * @param index Index of a file item in the model.
- * @return An appropriate icon name to represent this file.
- */
-QIcon QuestFilesModel::get_quest_file_icon(const QModelIndex& index) const {
-
-  QString icon_file_name;  // Relative to the icons directory.
-  QString file_path = get_file_path(index);
-  ResourceType resource_type;
-  QString element_id;
-
-  // Quest data directory.
-  if (is_quest_data_index(index)) {
-    icon_file_name = "icon_solarus.png";
-  }
-
-  // Resource element (possibly a directory for languages).
-  else if (quest.is_resource_element(file_path, resource_type, element_id)) {
-
-    QString resource_type_name = quest.get_resources().get_lua_name(resource_type);
-    if (quest.exists(quest.get_resource_element_path(resource_type, element_id))) {
-      // Resource declared and present on the filesystem.
-      icon_file_name = "icon_resource_" + resource_type_name + ".png";
-    }
-    else {
-      // Resource declared but whose file is missing.
-      icon_file_name = "icon_resource_" + resource_type_name + "_missing.png";
-    }
-  }
-
-  // Directory icon.
-  else if (quest.is_dir(file_path)) {
-
-    if (quest.is_resource_path(file_path, resource_type)) {
-      QString resource_type_name = quest.get_resources().get_lua_name(resource_type);
-      icon_file_name = "icon_folder_open_" + resource_type_name + ".png";
-    }
-    else {
-      icon_file_name = "icon_folder_open.png";
-    }
-  }
-
-  // Lua script icon.
-  else if (quest.is_script(file_path)) {
-    icon_file_name = "icon_script.png";
-  }
-
-  // Generic icon for a file not known by the quest.
-  else {
-    icon_file_name = "icon_file_unknown.png";
-  }
-
-  if (icon_file_name.isEmpty()) {
-    return QIcon();
-  }
-
-  return QIcon(":/images/" + icon_file_name);
 }
 
 /**

--- a/src/widgets/main_window.cpp
+++ b/src/widgets/main_window.cpp
@@ -66,7 +66,8 @@ MainWindow::MainWindow(QWidget* parent) :
   show_entities_button(nullptr),
   show_entities_subactions(),
   common_actions(),
-  settings_dialog(this) {
+  settings_dialog(this),
+  open_quest_file_dialog(this) {
 
   // Set up widgets.
   ui.setupUi(this);
@@ -162,6 +163,7 @@ MainWindow::MainWindow(QWidget* parent) :
   ui.action_close->setShortcut(QKeySequence::Close);
   ui.action_save->setShortcut(QKeySequence::Save);
   ui.action_exit->setShortcut(QKeySequence::Quit);
+  ui.action_open_quest_file->setShortcut(QKeySequence::Open);
   undo_action->setShortcut(QKeySequence::Undo);
   redo_action->setShortcut(QKeySequence::Redo);
   ui.action_cut->setShortcut(QKeySequence::Cut);
@@ -176,6 +178,7 @@ MainWindow::MainWindow(QWidget* parent) :
   addAction(ui.action_load_quest);
   addAction(ui.action_close_quest);
   addAction(ui.action_exit);
+  addAction(ui.action_open_quest_file);
   addAction(ui.action_close);
   addAction(ui.action_save);
   addAction(ui.action_cut);
@@ -231,6 +234,8 @@ MainWindow::MainWindow(QWidget* parent) :
 
   connect(&settings_dialog, SIGNAL(settings_changed()),
           this, SLOT(reload_settings()));
+  connect(&open_quest_file_dialog, SIGNAL(open_file_requested(Quest&,QString)),
+          ui.tab_widget, SLOT(open_file_requested(Quest&,QString)));
 
   // No editor initially.
   current_editor_changed(-1);
@@ -794,6 +799,16 @@ void MainWindow::on_action_close_triggered() {
 void MainWindow::on_action_close_all_triggered() {
 
   ui.tab_widget->close_all_files_requested();
+}
+
+/**
+ * @brief Slot called when the user triggers the "Open quest file" action.
+ */
+void MainWindow::on_action_open_quest_file_triggered() {
+
+  int x = width() / 2;
+  int y = ui.tool_bar->geometry().bottom();
+  open_quest_file_dialog.open_quest_file(&quest, mapToGlobal(QPoint(x, y)));
 }
 
 /**

--- a/src/widgets/main_window.ui
+++ b/src/widgets/main_window.ui
@@ -74,6 +74,7 @@
     <addaction name="action_load_quest"/>
     <addaction name="action_close_quest"/>
     <addaction name="separator"/>
+    <addaction name="action_open_quest_file"/>
     <addaction name="action_close"/>
     <addaction name="action_close_all"/>
     <addaction name="action_save"/>
@@ -445,6 +446,11 @@
    </property>
    <property name="shortcut">
     <string>Ctrl+P</string>
+   </property>
+  </action>
+  <action name="action_open_quest_file">
+   <property name="text">
+    <string>Open quest file</string>
    </property>
   </action>
  </widget>

--- a/src/widgets/open_quest_file_dialog.cpp
+++ b/src/widgets/open_quest_file_dialog.cpp
@@ -1,0 +1,353 @@
+/*
+ * Copyright (C) 2014-2016 Christopho, Solarus - http://www.solarus-games.org
+ *
+ * Solarus Quest Editor is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Solarus Quest Editor is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+#include "widgets/open_quest_file_dialog.h"
+#include "editor_settings.h"
+#include "quest.h"
+#include <QDirIterator>
+#include <QKeyEvent>
+#include <QPainter>
+#include <QStaticText>
+
+namespace SolarusEditor {
+
+const QString OpenQuestFileDialog::style_sheet =
+  "SolarusEditor--OpenQuestFileDialog {\n"
+  "  border: 1px solid %1;"
+  "  border-top: none;"
+  "}";
+
+/**
+ * @brief Creates a open quest file dialog.
+ * @param parent Parent object or nullptr.
+ */
+OpenQuestFileDialog::OpenQuestFileDialog(QWidget* parent) :
+  QDialog(parent),
+  quest(nullptr) {
+
+  ui.setupUi(this);
+
+  // Prepare the gui.
+  QPalette palette;
+  setStyleSheet(style_sheet.arg(palette.dark().color().name()));
+  setWindowFlags(Qt::Dialog | Qt::FramelessWindowHint);
+  setModal(false);
+  setFocusProxy(ui.search_field);
+
+  ui.list_widget->setFocusPolicy(Qt::NoFocus);
+  ui.list_widget->setEditTriggers(QAbstractItemView::NoEditTriggers);
+  ui.list_widget->setAlternatingRowColors(true);
+  ui.list_widget->setItemDelegate(new ItemDelegate);
+
+  // Load history.
+  EditorSettings settings;
+  history = settings.get_value_map(EditorSettings::open_quest_file_history);
+
+  // Make connections.
+  connect(ui.search_field, SIGNAL(textChanged(QString)),
+          this, SLOT(update_list()));
+  connect(ui.search_field, SIGNAL(focus_out(QFocusEvent*)),
+          this, SLOT(reject()));
+  connect(ui.list_widget, SIGNAL(doubleClicked(QModelIndex)),
+          this, SLOT(accept()));
+}
+
+/**
+ * @brief Shows this dialog to open a quest file.
+ * @param quest The quest.
+ * @param position The position where to show this dialog.
+ */
+void OpenQuestFileDialog::open_quest_file(
+  Quest* quest, const QPoint &position) {
+
+  this->quest = quest;
+  if (quest == nullptr) {
+    return;
+  }
+
+  QDirIterator it(
+    quest->get_data_path(),
+    QStringList() << "*.lua" << "*.dat",
+    QDir::Files,
+    QDirIterator::Subdirectories);
+
+  ui.list_widget->clear();
+  while (it.hasNext()) {
+    append_item(it.next());
+  }
+
+  update_list();
+
+  QRect rect = geometry();
+  QPoint pos = QPoint(position.x() - rect.width() / 2, position.y());
+  setGeometry(QRect(pos, rect.size()));
+  show();
+}
+
+/**
+ * @brief Closes the dialog unless the user tries to set invalid data.
+ * @param result Result code of the dialog.
+ */
+void OpenQuestFileDialog::done(int result) {
+
+  if (quest != nullptr && result == QDialog::Accepted) {
+    QString full_path =
+      ui.list_widget->currentIndex().data(FULL_PATH_ROLE).toString();
+    QString short_path =
+      ui.list_widget->currentIndex().data(SHORT_PATH_ROLE).toString();
+
+    EditorSettings settings;
+    history[ui.search_field->text()] = short_path;
+    settings.set_value(EditorSettings::open_quest_file_history, history);
+
+    emit open_file_requested(*quest, full_path);
+  }
+
+  QDialog::done(result);
+}
+
+/**
+ * @brief Called when the user press a key.
+ * @param event The event.
+ */
+void OpenQuestFileDialog::keyPressEvent(QKeyEvent* event) {
+
+  int key = event->key();
+
+  if (key == Qt::Key_Up || key == Qt::Key_Down) {
+
+    int row = ui.list_widget->currentRow() + (key == Qt::Key_Down ? 1 : -1);
+    if (row < 0) {
+      row = ui.list_widget->count() - 1;
+    }
+
+    ui.list_widget->setCurrentRow(row);
+    select_visible_item(key == Qt::Key_Up);
+    event->accept();
+  }
+  else if (key == Qt::Key_PageUp) {
+    ui.list_widget->setCurrentRow(0);
+    select_visible_item();
+    event->accept();
+  }
+  else if (key == Qt::Key_PageDown) {
+    ui.list_widget->setCurrentRow(ui.list_widget->count() - 1);
+    select_visible_item(true);
+    event->accept();
+  }
+  else if (key == Qt::Key_Return || key == Qt::Key_Enter) {
+    accept();
+    event->accept();
+  }
+
+  QDialog::keyPressEvent(event);
+}
+
+/**
+ * @brief Updates the list widget.
+ */
+void OpenQuestFileDialog::update_list() {
+
+  ui.list_widget->sortItems();
+  ui.list_widget->setCurrentRow(-1);
+
+  int top = 0;
+  for (int i = 0; i < ui.list_widget->count(); ++i) {
+    update_item(ui.list_widget->item(i), top);
+  }
+
+  if (ui.list_widget->currentRow() == -1) {
+    select_visible_item();
+  }
+}
+
+/**
+ * @brief Appends an item in the list widget.
+ * @param full_path The file path of the item to append.
+ */
+void OpenQuestFileDialog::append_item(const QString& full_path) {
+
+  QString data_path = quest->get_data_path();
+  QString short_path = QString(full_path).replace(data_path + "/", "");
+  short_path.replace(QRegularExpression("\\.dat$"), "");
+  QIcon icon = quest->get_file_icon(full_path);
+
+  QListWidgetItem* item = new QListWidgetItem(icon, short_path);
+  item->setData(FULL_PATH_ROLE, full_path);
+  item->setData(SHORT_PATH_ROLE, short_path);
+
+  ui.list_widget->addItem(item);
+}
+
+/**
+ * @brief Updates an item.
+ * @param item The item to update.
+ * @param top The top position where to move an exact matched item.
+ */
+void OpenQuestFileDialog::update_item(QListWidgetItem* item, int& top) {
+
+  QString text = ui.search_field->text();
+  QString short_path = item->data(SHORT_PATH_ROLE).toString();
+  QString pattern;
+  for (const QChar& c: text) {
+    pattern += QString(".*(%1)").arg(QRegularExpression::escape(QString(c)));
+  }
+
+  QRegularExpression general_regex(QString("^%1.*$").arg(pattern));
+  QRegularExpressionMatch general_match = general_regex.match(short_path);
+  if (general_match.hasMatch()) {
+
+    QRegularExpression exact_regex(
+      QString("^.*(%1).*$").arg(QRegularExpression::escape(text)));
+    QRegularExpressionMatch exact_match = exact_regex.match(short_path);
+    if (exact_match.hasMatch()) {
+      ui.list_widget->takeItem(ui.list_widget->row(item));
+      ui.list_widget->insertItem(top++, item);
+      update_display(item, exact_match);
+    } else {
+      update_display(item, general_match);
+    }
+
+    // Selected if is corresponding to the history.
+    if (history.contains(text)) {
+      if (history[text].toString() == short_path) {
+        ui.list_widget->setCurrentItem(item);
+      }
+    }
+
+    item->setHidden(false);
+  } else {
+    item->setHidden(true);
+  }
+}
+
+/**
+ * @brief Update the displayed text of an item.
+ * @param item The item to update.
+ * @param match The match result.
+ */
+void OpenQuestFileDialog::update_display(
+  QListWidgetItem* item, const QRegularExpressionMatch& match) {
+
+  QString short_path = match.captured(0);
+  QString display;
+  int p = 0;
+  for (int i = 1; i <= match.lastCapturedIndex(); ++i) {
+    int start = match.capturedStart(i);
+    if (p < start) {
+      display += short_path.mid(p, start - p);
+    }
+    display += QString("<b>%1</b>").arg(match.captured(i));
+    p = match.capturedEnd(i);
+  }
+  display += short_path.mid(p);
+
+  item->setData(Qt::DisplayRole, display);
+}
+
+/**
+ * @brief Selects the first visible item from the current one (included).
+ * @param to_up Set to @c true to select by up.
+ */
+void OpenQuestFileDialog::select_visible_item(bool to_up) {
+
+  int count = ui.list_widget->count();
+  if (count == 0) {
+    return;
+  }
+
+  int row = qBound(0, ui.list_widget->currentRow(), count);
+  int row_start = row;
+  QListWidgetItem* item;
+
+  do {
+    item = ui.list_widget->item(row);
+
+    if (to_up) {
+      row--;
+      if (row < 0) {
+        row = count - 1;
+      }
+    } else {
+      row++;
+      if (row >= count) {
+        row = 0;
+      }
+    }
+
+    if (row == row_start) {
+      return; // no visible item.
+    }
+  } while(item->isHidden());
+
+  ui.list_widget->setCurrentItem(item);
+}
+
+/**
+ * @brief Create a item delegate.
+ * @param parent The parent.
+ */
+OpenQuestFileDialog::ItemDelegate::ItemDelegate(QObject* parent) :
+  QStyledItemDelegate(parent) {
+}
+
+/**
+ * @brief Paints an item.
+ * @param painter The painter.
+ * @param option The option.
+ * @param index The index of the item.
+ */
+void OpenQuestFileDialog::ItemDelegate::paint(
+  QPainter* painter, const QStyleOptionViewItem& option,
+  const QModelIndex& index) const {
+
+  QString display = index.data(Qt::DisplayRole).toString();
+  QIcon icon = qvariant_cast<QIcon>(index.data(Qt::DecorationRole));
+  QPoint pos = option.rect.topLeft() + QPoint(2, 2);
+
+  painter->save();
+
+  if (option.state & QStyle::State_Selected) {
+    painter->fillRect(option.rect, option.palette.highlight());
+    painter->setPen(option.palette.highlightedText().color());
+  }
+
+  painter->drawPixmap(pos, icon.pixmap(16, 16));
+
+  QStaticText text(display);
+  text.setTextWidth(option.rect.width());
+  painter->drawStaticText(pos.x() + 20, pos.y(), text);
+
+  painter->restore();
+}
+
+/**
+ * @brief Returns the size hint.
+ * @param option The option.
+ * @param index The index.
+ * @return The size hint.
+ */
+QSize OpenQuestFileDialog::ItemDelegate::sizeHint(
+  const QStyleOptionViewItem& /*option*/,
+  const QModelIndex &index) const {
+
+  QString display = index.data(SHORT_PATH_ROLE).toString();
+  QFontMetrics metrics = QFontMetrics(QApplication::font());
+  QSize size = metrics.boundingRect(display).size() + QSize(24, 4);
+  return size;
+}
+
+}

--- a/src/widgets/open_quest_file_dialog.ui
+++ b/src/widgets/open_quest_file_dialog.ui
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>SolarusEditor::OpenQuestFileDialog</class>
+ <widget class="QDialog" name="SolarusEditor::OpenQuestFileDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>600</width>
+    <height>189</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Open quest file</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="spacing">
+    <number>4</number>
+   </property>
+   <property name="leftMargin">
+    <number>4</number>
+   </property>
+   <property name="topMargin">
+    <number>4</number>
+   </property>
+   <property name="rightMargin">
+    <number>4</number>
+   </property>
+   <property name="bottomMargin">
+    <number>4</number>
+   </property>
+   <item>
+    <widget class="LineEdit" name="search_field"/>
+   </item>
+   <item>
+    <widget class="QListWidget" name="list_widget"/>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>LineEdit</class>
+   <extends>QLineEdit</extends>
+   <header>widgets/line_edit.h</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/translations/solarus_editor_fr.ts
+++ b/translations/solarus_editor_fr.ts
@@ -1791,184 +1791,189 @@ Make sure that Solarus Quest Editor is properly installed.</source>
         <translation>Fichier</translation>
     </message>
     <message>
-        <location filename="../src/widgets/main_window.ui" line="87"/>
+        <location filename="../src/widgets/main_window.ui" line="88"/>
         <source>Edit</source>
         <translation>Édition</translation>
     </message>
     <message>
-        <location filename="../src/widgets/main_window.ui" line="101"/>
+        <location filename="../src/widgets/main_window.ui" line="102"/>
         <source>Run</source>
         <translation>Exécuter</translation>
     </message>
     <message>
-        <location filename="../src/widgets/main_window.ui" line="107"/>
+        <location filename="../src/widgets/main_window.ui" line="108"/>
         <source>View</source>
         <translation>Affichage</translation>
     </message>
     <message>
-        <location filename="../src/widgets/main_window.ui" line="120"/>
+        <location filename="../src/widgets/main_window.ui" line="121"/>
         <source>Help</source>
         <translation>Aide</translation>
     </message>
     <message>
-        <location filename="../src/widgets/main_window.ui" line="127"/>
+        <location filename="../src/widgets/main_window.ui" line="128"/>
         <source>Tools</source>
         <translation>Outils</translation>
     </message>
     <message>
-        <location filename="../src/widgets/main_window.ui" line="133"/>
+        <location filename="../src/widgets/main_window.ui" line="134"/>
         <source>Audio</source>
         <translation>Audio</translation>
     </message>
     <message>
-        <location filename="../src/widgets/main_window.ui" line="173"/>
+        <location filename="../src/widgets/main_window.ui" line="174"/>
         <source>New quest...</source>
         <translation>Nouvelle quête...</translation>
     </message>
     <message>
-        <location filename="../src/widgets/main_window.ui" line="178"/>
+        <location filename="../src/widgets/main_window.ui" line="179"/>
         <source>Load quest...</source>
         <translation>Ouvrir une quête...</translation>
     </message>
     <message>
-        <location filename="../src/widgets/main_window.ui" line="181"/>
+        <location filename="../src/widgets/main_window.ui" line="182"/>
         <source>Ctrl+L</source>
         <translation>Ctrl+L</translation>
     </message>
     <message>
-        <location filename="../src/widgets/main_window.ui" line="186"/>
+        <location filename="../src/widgets/main_window.ui" line="187"/>
         <source>Exit</source>
         <translation>Quitter</translation>
     </message>
     <message>
-        <location filename="../src/widgets/main_window.ui" line="195"/>
-        <location filename="../src/widgets/main_window.cpp" line="1435"/>
+        <location filename="../src/widgets/main_window.ui" line="196"/>
+        <location filename="../src/widgets/main_window.cpp" line="1450"/>
         <source>Run quest</source>
         <translation>Exécuter la quête</translation>
     </message>
     <message>
-        <location filename="../src/widgets/main_window.ui" line="198"/>
+        <location filename="../src/widgets/main_window.ui" line="199"/>
         <source>F5</source>
         <translation>F5</translation>
     </message>
     <message>
-        <location filename="../src/widgets/main_window.ui" line="269"/>
-        <location filename="../src/widgets/main_window.ui" line="272"/>
+        <location filename="../src/widgets/main_window.ui" line="270"/>
+        <location filename="../src/widgets/main_window.ui" line="273"/>
         <source>Show layer 0</source>
         <translation>Afficher la couche 0</translation>
     </message>
     <message>
-        <location filename="../src/widgets/main_window.ui" line="275"/>
+        <location filename="../src/widgets/main_window.ui" line="276"/>
         <source>0</source>
         <translation>0</translation>
     </message>
     <message>
-        <location filename="../src/widgets/main_window.ui" line="290"/>
-        <location filename="../src/widgets/main_window.ui" line="293"/>
+        <location filename="../src/widgets/main_window.ui" line="291"/>
+        <location filename="../src/widgets/main_window.ui" line="294"/>
         <source>Show layer 1</source>
         <translation>Afficher la couche 1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/main_window.ui" line="296"/>
+        <location filename="../src/widgets/main_window.ui" line="297"/>
         <source>1</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/widgets/main_window.ui" line="311"/>
-        <location filename="../src/widgets/main_window.ui" line="314"/>
+        <location filename="../src/widgets/main_window.ui" line="312"/>
+        <location filename="../src/widgets/main_window.ui" line="315"/>
         <source>Show layer 2</source>
         <translation>Afficher la couche 2</translation>
     </message>
     <message>
-        <location filename="../src/widgets/main_window.ui" line="317"/>
+        <location filename="../src/widgets/main_window.ui" line="318"/>
         <source>2</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/widgets/main_window.ui" line="357"/>
+        <location filename="../src/widgets/main_window.ui" line="358"/>
         <source>Select all</source>
         <translation>Sélectionner tout</translation>
     </message>
     <message>
-        <location filename="../src/widgets/main_window.ui" line="362"/>
+        <location filename="../src/widgets/main_window.ui" line="363"/>
         <source>Save all</source>
         <translation>Enregistrer tout</translation>
     </message>
     <message>
-        <location filename="../src/widgets/main_window.ui" line="365"/>
+        <location filename="../src/widgets/main_window.ui" line="366"/>
         <source>Ctrl+Shift+S</source>
         <translation>Ctrl+Shift+S</translation>
     </message>
     <message>
-        <location filename="../src/widgets/main_window.ui" line="370"/>
+        <location filename="../src/widgets/main_window.ui" line="371"/>
         <source>Close all</source>
         <translation>Fermer tout</translation>
     </message>
     <message>
-        <location filename="../src/widgets/main_window.ui" line="373"/>
+        <location filename="../src/widgets/main_window.ui" line="374"/>
         <source>Ctrl+Shift+W</source>
         <translation>Ctrl+Shift+W</translation>
     </message>
     <message>
-        <location filename="../src/widgets/main_window.ui" line="381"/>
+        <location filename="../src/widgets/main_window.ui" line="382"/>
         <source>Show console</source>
         <translation>Afficher la console</translation>
     </message>
     <message>
-        <location filename="../src/widgets/main_window.ui" line="384"/>
+        <location filename="../src/widgets/main_window.ui" line="385"/>
         <source>F12</source>
         <translation>F12</translation>
     </message>
     <message>
-        <location filename="../src/widgets/main_window.ui" line="392"/>
+        <location filename="../src/widgets/main_window.ui" line="393"/>
         <source>Unselect all</source>
         <translation>Déselectionner tout</translation>
     </message>
     <message>
-        <location filename="../src/widgets/main_window.ui" line="397"/>
+        <location filename="../src/widgets/main_window.ui" line="398"/>
         <source>Close quest</source>
         <translation>Fermer la quête</translation>
     </message>
     <message>
-        <location filename="../src/widgets/main_window.ui" line="406"/>
-        <location filename="../src/widgets/main_window.cpp" line="1484"/>
-        <location filename="../src/widgets/main_window.cpp" line="1491"/>
+        <location filename="../src/widgets/main_window.ui" line="407"/>
+        <location filename="../src/widgets/main_window.cpp" line="1499"/>
+        <location filename="../src/widgets/main_window.cpp" line="1506"/>
         <source>Pause music</source>
         <translation>Mettre la musique en pause</translation>
     </message>
     <message>
-        <location filename="../src/widgets/main_window.ui" line="415"/>
-        <location filename="../src/widgets/main_window.cpp" line="1480"/>
+        <location filename="../src/widgets/main_window.ui" line="416"/>
+        <location filename="../src/widgets/main_window.cpp" line="1495"/>
         <source>Stop music</source>
         <translation>Arrêter la musique</translation>
     </message>
     <message>
-        <location filename="../src/widgets/main_window.ui" line="427"/>
+        <location filename="../src/widgets/main_window.ui" line="428"/>
         <source>Show traversable entities</source>
         <translation>Afficher les entités traversables</translation>
     </message>
     <message>
-        <location filename="../src/widgets/main_window.ui" line="439"/>
+        <location filename="../src/widgets/main_window.ui" line="440"/>
         <source>Show obstacle entities</source>
         <translation>Afficher les entités obstacles</translation>
     </message>
     <message>
-        <location filename="../src/widgets/main_window.ui" line="444"/>
+        <location filename="../src/widgets/main_window.ui" line="445"/>
         <source>Quest properties</source>
         <translation>Propriétés de la quête</translation>
     </message>
     <message>
-        <location filename="../src/widgets/main_window.ui" line="447"/>
+        <location filename="../src/widgets/main_window.ui" line="448"/>
         <source>Ctrl+P</source>
         <translation>Ctrl+P</translation>
     </message>
     <message>
-        <location filename="../src/widgets/main_window.ui" line="343"/>
+        <location filename="../src/widgets/main_window.ui" line="453"/>
+        <source>Open quest file</source>
+        <translation>Ouvrir un fichier de quête</translation>
+    </message>
+    <message>
+        <location filename="../src/widgets/main_window.ui" line="344"/>
         <source>Find...</source>
         <translation>Rechercher...</translation>
     </message>
     <message>
-        <location filename="../src/widgets/main_window.ui" line="348"/>
+        <location filename="../src/widgets/main_window.ui" line="349"/>
         <source>Options</source>
         <translation>Options</translation>
     </message>
@@ -1977,37 +1982,37 @@ Make sure that Solarus Quest Editor is properly installed.</source>
         <translation type="vanished">Paramètres</translation>
     </message>
     <message>
-        <location filename="../src/widgets/main_window.ui" line="207"/>
+        <location filename="../src/widgets/main_window.ui" line="208"/>
         <source>Cut</source>
         <translation>Couper</translation>
     </message>
     <message>
-        <location filename="../src/widgets/main_window.ui" line="216"/>
+        <location filename="../src/widgets/main_window.ui" line="217"/>
         <source>Copy</source>
         <translation>Copier</translation>
     </message>
     <message>
-        <location filename="../src/widgets/main_window.ui" line="225"/>
+        <location filename="../src/widgets/main_window.ui" line="226"/>
         <source>Paste</source>
         <translation>Coller</translation>
     </message>
     <message>
-        <location filename="../src/widgets/main_window.ui" line="230"/>
+        <location filename="../src/widgets/main_window.ui" line="231"/>
         <source>Close</source>
         <translation>Fermer</translation>
     </message>
     <message>
-        <location filename="../src/widgets/main_window.ui" line="239"/>
+        <location filename="../src/widgets/main_window.ui" line="240"/>
         <source>Save</source>
         <translation>Enregistrer</translation>
     </message>
     <message>
-        <location filename="../src/widgets/main_window.ui" line="251"/>
+        <location filename="../src/widgets/main_window.ui" line="252"/>
         <source>Show grid</source>
         <translation>Afficher la grille</translation>
     </message>
     <message>
-        <location filename="../src/widgets/main_window.ui" line="254"/>
+        <location filename="../src/widgets/main_window.ui" line="255"/>
         <source>Ctrl+G</source>
         <translation>Ctrl+G</translation>
     </message>
@@ -2036,23 +2041,23 @@ Make sure that Solarus Quest Editor is properly installed.</source>
         <translation type="vanished">Ctrl+3</translation>
     </message>
     <message>
-        <location filename="../src/widgets/main_window.ui" line="326"/>
+        <location filename="../src/widgets/main_window.ui" line="327"/>
         <source>Documentation</source>
         <translation>Documentation</translation>
     </message>
     <message>
-        <location filename="../src/widgets/main_window.ui" line="329"/>
+        <location filename="../src/widgets/main_window.ui" line="330"/>
         <source>F1</source>
         <translation>F1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/main_window.ui" line="338"/>
+        <location filename="../src/widgets/main_window.ui" line="339"/>
         <source>Website</source>
         <translation>Site web</translation>
     </message>
     <message>
-        <location filename="../src/widgets/main_window.cpp" line="695"/>
-        <location filename="../src/widgets/main_window.cpp" line="733"/>
+        <location filename="../src/widgets/main_window.cpp" line="700"/>
+        <location filename="../src/widgets/main_window.cpp" line="738"/>
         <source>Select quest directory</source>
         <translation>Choisir le dossier de la quête</translation>
     </message>
@@ -2070,14 +2075,14 @@ La prochaine étape est de modifier manuellement les propriétés de votre quêt
 (désolé, l&apos;éditeur ne sait pas encore le faire interactivement).</translation>
     </message>
     <message>
-        <location filename="../src/widgets/main_window.cpp" line="536"/>
+        <location filename="../src/widgets/main_window.cpp" line="541"/>
         <source>No quest was found in directory
 &apos;%1&apos;</source>
         <translation>Aucune quête n&apos;a été trouvée dans le dossier &apos;%1&apos;</translation>
     </message>
     <message>
-        <location filename="../src/widgets/main_window.cpp" line="117"/>
-        <location filename="../src/widgets/main_window.cpp" line="307"/>
+        <location filename="../src/widgets/main_window.cpp" line="118"/>
+        <location filename="../src/widgets/main_window.cpp" line="312"/>
         <source>Zoom</source>
         <translation>Zoom</translation>
     </message>
@@ -2086,27 +2091,27 @@ La prochaine étape est de modifier manuellement les propriétés de votre quêt
         <translation type="vanished">Afficher les types d&apos;entités</translation>
     </message>
     <message>
-        <location filename="../src/widgets/main_window.cpp" line="309"/>
+        <location filename="../src/widgets/main_window.cpp" line="314"/>
         <source>25 %</source>
         <translation>25 %</translation>
     </message>
     <message>
-        <location filename="../src/widgets/main_window.cpp" line="310"/>
+        <location filename="../src/widgets/main_window.cpp" line="315"/>
         <source>50 %</source>
         <translation>50 %</translation>
     </message>
     <message>
-        <location filename="../src/widgets/main_window.cpp" line="311"/>
+        <location filename="../src/widgets/main_window.cpp" line="316"/>
         <source>100 %</source>
         <translation>100 %</translation>
     </message>
     <message>
-        <location filename="../src/widgets/main_window.cpp" line="312"/>
+        <location filename="../src/widgets/main_window.cpp" line="317"/>
         <source>200 %</source>
         <translation>200 %</translation>
     </message>
     <message>
-        <location filename="../src/widgets/main_window.cpp" line="313"/>
+        <location filename="../src/widgets/main_window.cpp" line="318"/>
         <source>400 %</source>
         <translation>400 %</translation>
     </message>
@@ -2119,105 +2124,105 @@ La prochaine étape est de modifier manuellement les propriétés de votre quêt
         <translation type="vanished">Cacher tout</translation>
     </message>
     <message>
-        <location filename="../src/widgets/main_window.cpp" line="96"/>
+        <location filename="../src/widgets/main_window.cpp" line="97"/>
         <source>Recent quests</source>
         <translation>Quêtes récentes</translation>
     </message>
     <message>
-        <location filename="../src/widgets/main_window.cpp" line="137"/>
+        <location filename="../src/widgets/main_window.cpp" line="138"/>
         <source>Show/hide more layers</source>
         <translation>Afficher/cacher plus de couches</translation>
     </message>
     <message>
-        <location filename="../src/widgets/main_window.cpp" line="147"/>
-        <location filename="../src/widgets/main_window.cpp" line="409"/>
+        <location filename="../src/widgets/main_window.cpp" line="148"/>
+        <location filename="../src/widgets/main_window.cpp" line="414"/>
         <source>Show/hide entity types</source>
         <translation>Afficher/cacher des types d&apos;entités</translation>
     </message>
     <message>
-        <location filename="../src/widgets/main_window.cpp" line="241"/>
+        <location filename="../src/widgets/main_window.cpp" line="246"/>
         <source>Could not locate the assets directory.
 Some features like creating a new quest will not be available.
 Please make sure that Solarus Quest Editor is correctly installed.</source>
         <translation>Impossible de trouver le dossier &quot;assets&quot;.\nCertaines fonctionnalité commes créer une nouvelle quête ne seront pas disponibles.\nVérifiez que Solarus Quest Editor est correctement installé.</translation>
     </message>
     <message>
-        <location filename="../src/widgets/main_window.cpp" line="349"/>
+        <location filename="../src/widgets/main_window.cpp" line="354"/>
         <source>Show all layers</source>
         <translation>Afficher toutes les couches</translation>
     </message>
     <message>
-        <location filename="../src/widgets/main_window.cpp" line="359"/>
+        <location filename="../src/widgets/main_window.cpp" line="364"/>
         <source>Hide all layers</source>
         <translation>Cacher toutes les couches</translation>
     </message>
     <message>
-        <location filename="../src/widgets/main_window.cpp" line="378"/>
+        <location filename="../src/widgets/main_window.cpp" line="383"/>
         <source>Show layer %1</source>
         <translation>Afficher la couche %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/main_window.cpp" line="438"/>
+        <location filename="../src/widgets/main_window.cpp" line="443"/>
         <source>Show all entities</source>
         <translation>Afficher toutes les entités</translation>
     </message>
     <message>
-        <location filename="../src/widgets/main_window.cpp" line="448"/>
+        <location filename="../src/widgets/main_window.cpp" line="453"/>
         <source>Hide all entities</source>
         <translation>Cacher toutes les entités</translation>
     </message>
     <message>
-        <location filename="../src/widgets/main_window.cpp" line="563"/>
+        <location filename="../src/widgets/main_window.cpp" line="568"/>
         <source>Obsolete quest</source>
         <translation>Quête obsolète</translation>
     </message>
     <message>
-        <location filename="../src/widgets/main_window.cpp" line="564"/>
+        <location filename="../src/widgets/main_window.cpp" line="569"/>
         <source>The format of this quest (%1) is outdated.
 Your data files will be automatically updated to Solarus %2.</source>
         <translation>Le format de cette quête (%1) is obsolète.
 Vos fichiers de données vont être automatiquement mis à jour vers Solarus %2.</translation>
     </message>
     <message>
-        <location filename="../src/widgets/main_window.cpp" line="616"/>
+        <location filename="../src/widgets/main_window.cpp" line="621"/>
         <source>Upgrading quest data files</source>
         <translation>Mise à jour des données de la quête</translation>
     </message>
     <message>
-        <location filename="../src/widgets/main_window.cpp" line="633"/>
+        <location filename="../src/widgets/main_window.cpp" line="638"/>
         <source>An error occured while upgrading the quest.
 Your quest was kept unchanged in format %1.</source>
         <translation>Une erreur s&apos;est produite lors de la mise à jour de la quête.
 Votre quête a été conservée inchangée au format %1.</translation>
     </message>
     <message>
-        <location filename="../src/widgets/main_window.cpp" line="681"/>
+        <location filename="../src/widgets/main_window.cpp" line="686"/>
         <source>Could not find the assets directory.
 Make sure that Solarus Quest Editor is properly installed.</source>
         <translation>Impossible de trouver le dossier &quot;assets&quot;.\nVérifiez que Solarus Quest Editor est correctement installé.</translation>
     </message>
     <message>
-        <location filename="../src/widgets/main_window.cpp" line="905"/>
+        <location filename="../src/widgets/main_window.cpp" line="920"/>
         <source>Files are modified</source>
         <translation>Modifications non sauvegardées</translation>
     </message>
     <message>
-        <location filename="../src/widgets/main_window.cpp" line="906"/>
+        <location filename="../src/widgets/main_window.cpp" line="921"/>
         <source>Do you want to save modifications before running the quest?</source>
         <translation>Enregistrer les modifications avant de lancer la quête ?</translation>
     </message>
     <message>
-        <location filename="../src/widgets/main_window.cpp" line="1432"/>
+        <location filename="../src/widgets/main_window.cpp" line="1447"/>
         <source>Stop quest</source>
         <translation>Arrêter la quête</translation>
     </message>
     <message>
-        <location filename="../src/widgets/main_window.cpp" line="1688"/>
+        <location filename="../src/widgets/main_window.cpp" line="1703"/>
         <source>Unsaved changes</source>
         <translation>Changements non sauvegardés</translation>
     </message>
     <message>
-        <location filename="../src/widgets/main_window.cpp" line="1689"/>
+        <location filename="../src/widgets/main_window.cpp" line="1704"/>
         <source>All files must be saved before this operation.
 Do you want to save them now?</source>
         <translation>Tous les fichiers doivent être sauvegardés avant d&apos;effectuer cette opération.\nVoulez-vous les sauvegarder maintenant ?</translation>
@@ -2227,12 +2232,12 @@ Do you want to save them now?</source>
         <translation type="vanished">La quête s&apos;est terminée avec une erreur : %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/main_window.cpp" line="1604"/>
+        <location filename="../src/widgets/main_window.cpp" line="1619"/>
         <source>File modified</source>
         <translation>Fichier en cours de modification</translation>
     </message>
     <message>
-        <location filename="../src/widgets/main_window.cpp" line="1605"/>
+        <location filename="../src/widgets/main_window.cpp" line="1620"/>
         <source>This file is open and has unsaved changes.
 Please save it or close it before renaming.</source>
         <translation>Ce fichier est ouvert et a été modifié.\nVeuillez le sauvegarder ou le fermer avant de le renommer.</translation>
@@ -2246,12 +2251,12 @@ Please save it or close it before renaming.</source>
         <translation type="vanished">Nouvel id pour %1 &apos;%2&apos; :</translation>
     </message>
     <message>
-        <location filename="../src/widgets/main_window.cpp" line="1651"/>
+        <location filename="../src/widgets/main_window.cpp" line="1666"/>
         <source>Rename file</source>
         <translation>Renommer le fichier</translation>
     </message>
     <message>
-        <location filename="../src/widgets/main_window.cpp" line="1652"/>
+        <location filename="../src/widgets/main_window.cpp" line="1667"/>
         <source>New name for file &apos;%1&apos;:</source>
         <translation>Nouveau nom pour le fichier &apos;%1&apos; :</translation>
     </message>
@@ -2260,17 +2265,17 @@ Please save it or close it before renaming.</source>
         <translation type="vanished">Couche invalide : %1</translation>
     </message>
     <message>
-        <location filename="../src/widgets/main_window.cpp" line="1415"/>
+        <location filename="../src/widgets/main_window.cpp" line="1430"/>
         <source>Missing show entity type action</source>
         <translation>Action d&apos;affichage d&apos;entité introuvable</translation>
     </message>
     <message>
-        <location filename="../src/widgets/main_window.cpp" line="1488"/>
+        <location filename="../src/widgets/main_window.cpp" line="1503"/>
         <source>Play selected music</source>
         <translation>Jouer la musique sélectionnée</translation>
     </message>
     <message>
-        <location filename="../src/widgets/main_window.cpp" line="1523"/>
+        <location filename="../src/widgets/main_window.cpp" line="1538"/>
         <source>Solarus Quest Editor %1</source>
         <translation>Solarus Quest Editor %1</translation>
     </message>
@@ -3153,6 +3158,14 @@ Please save it or close it before renaming.</source>
     </message>
 </context>
 <context>
+    <name>SolarusEditor::OpenQuestFileDialog</name>
+    <message>
+        <location filename="../src/widgets/open_quest_file_dialog.ui" line="14"/>
+        <source>Open quest file</source>
+        <translation>Ouvrir un fichier de quête</translation>
+    </message>
+</context>
+<context>
     <name>SolarusEditor::Quest</name>
     <message>
         <location filename="../src/quest.cpp" line="266"/>
@@ -3160,32 +3173,32 @@ Please save it or close it before renaming.</source>
         <translation>Type de ressource inconnu</translation>
     </message>
     <message>
-        <location filename="../src/quest.cpp" line="919"/>
+        <location filename="../src/quest.cpp" line="978"/>
         <source>Invalid file name: &apos;%1&apos;</source>
         <translation>Nom de fichier invalide : &apos;%1&apos;</translation>
     </message>
     <message>
-        <location filename="../src/quest.cpp" line="977"/>
+        <location filename="../src/quest.cpp" line="1036"/>
         <source>File &apos;%1&apos; does not exist</source>
         <translation>Le fichier &apos;%1&apos; n&apos;existe pas</translation>
     </message>
     <message>
-        <location filename="../src/quest.cpp" line="990"/>
+        <location filename="../src/quest.cpp" line="1049"/>
         <source>File &apos;%1&apos; already exists</source>
         <translation>Le fichier &apos;%1&apos; existe déjà</translation>
     </message>
     <message>
-        <location filename="../src/quest.cpp" line="1051"/>
+        <location filename="../src/quest.cpp" line="1110"/>
         <source>Wrong script name: &apos;%1&apos; (should end with &apos;.lua&apos;)</source>
         <translation>Nom de script incorrect : &apos;%1&apos; (extension &apos;.lua&apos; attendue)</translation>
     </message>
     <message>
-        <location filename="../src/quest.cpp" line="1066"/>
+        <location filename="../src/quest.cpp" line="1125"/>
         <source>Cannot create file &apos;%1&apos;</source>
         <translation>Impossible de créer le fichier &apos;%1&apos;</translation>
     </message>
     <message>
-        <location filename="../src/quest.cpp" line="916"/>
+        <location filename="../src/quest.cpp" line="975"/>
         <source>Empty file name</source>
         <translation>Nom de fichier vide</translation>
     </message>
@@ -3195,76 +3208,76 @@ Please save it or close it before renaming.</source>
         <translation>Pas de quête</translation>
     </message>
     <message>
-        <location filename="../src/quest.cpp" line="1013"/>
+        <location filename="../src/quest.cpp" line="1072"/>
         <source>File &apos;%1&apos; is not a folder</source>
         <translation>Le fichier &apos;%1&apos; n&apos;est pas un dossier</translation>
     </message>
     <message>
-        <location filename="../src/quest.cpp" line="1026"/>
+        <location filename="../src/quest.cpp" line="1085"/>
         <source>File &apos;%1&apos; is a folder</source>
         <translation>Le fichier &apos;%1&apos; est un dossier</translation>
     </message>
     <message>
-        <location filename="../src/quest.cpp" line="1091"/>
+        <location filename="../src/quest.cpp" line="1150"/>
         <source>Cannot read file &apos;%1&apos;</source>
         <translation>Impossible de lire le fichier &apos;%1&apos;</translation>
     </message>
     <message>
-        <location filename="../src/quest.cpp" line="1099"/>
+        <location filename="../src/quest.cpp" line="1158"/>
         <source>Cannot write file &apos;%1&apos;</source>
         <translation>Impossible d&apos;écrire le fichier &apos;%1&apos;</translation>
     </message>
     <message>
-        <location filename="../src/quest.cpp" line="1357"/>
+        <location filename="../src/quest.cpp" line="1416"/>
         <source>Cannot create folder &apos;%1&apos;: parent folder does not exist</source>
         <translation>Impossible de créer le dossier &apos;%1&apos; : le dossier parent n&apos;existe pas</translation>
     </message>
     <message>
-        <location filename="../src/quest.cpp" line="1363"/>
-        <location filename="../src/quest.cpp" line="1400"/>
+        <location filename="../src/quest.cpp" line="1422"/>
+        <location filename="../src/quest.cpp" line="1459"/>
         <source>Cannot create folder &apos;%1&apos;</source>
         <translation>Impossible de créer le dossier &apos;%1&apos;</translation>
     </message>
     <message>
-        <location filename="../src/quest.cpp" line="1516"/>
+        <location filename="../src/quest.cpp" line="1575"/>
         <source>Resource &apos;%1&apos; already exists</source>
         <translation>La ressource &apos;%1&apos; existe déjà</translation>
     </message>
     <message>
-        <location filename="../src/quest.cpp" line="1532"/>
+        <location filename="../src/quest.cpp" line="1591"/>
         <source>Cannot rename file &apos;%1&apos;</source>
         <translation>Impossible de renommer le fichier &apos;%1&apos;</translation>
     </message>
     <message>
-        <location filename="../src/quest.cpp" line="1643"/>
+        <location filename="../src/quest.cpp" line="1702"/>
         <source>Cannot delete file &apos;%1&apos;</source>
         <translation>Impossible de supprimer le fichier &apos;%1&apos;</translation>
     </message>
     <message>
-        <location filename="../src/quest.cpp" line="1677"/>
-        <location filename="../src/quest.cpp" line="1708"/>
+        <location filename="../src/quest.cpp" line="1736"/>
+        <location filename="../src/quest.cpp" line="1767"/>
         <source>Cannot delete folder &apos;%1&apos;</source>
         <translation>Impossible de supprimer le dossier &apos;%1&apos;</translation>
     </message>
     <message>
-        <location filename="../src/quest.cpp" line="1578"/>
+        <location filename="../src/quest.cpp" line="1637"/>
         <source>Same source and destination id</source>
         <translation>Id source et destination identiques</translation>
     </message>
     <message>
-        <location filename="../src/quest.cpp" line="1585"/>
+        <location filename="../src/quest.cpp" line="1644"/>
         <source>A resource with id &apos;%1&apos; already exists</source>
         <translation>Une ressource avec l&apos;id &apos;%1&apos; existe déjà</translation>
     </message>
     <message>
-        <location filename="../src/quest.cpp" line="1590"/>
-        <location filename="../src/quest.cpp" line="1629"/>
-        <location filename="../src/quest.cpp" line="1771"/>
+        <location filename="../src/quest.cpp" line="1649"/>
+        <location filename="../src/quest.cpp" line="1688"/>
+        <location filename="../src/quest.cpp" line="1830"/>
         <source>No such resource: &apos;%1&apos;</source>
         <translation>Ressource inexistante : &apos;%1&apos;</translation>
     </message>
     <message>
-        <location filename="../src/quest.cpp" line="954"/>
+        <location filename="../src/quest.cpp" line="1013"/>
         <source>File &apos;%1&apos; is not in this quest</source>
         <translation>Le fichier &apos;%1&apos; ne fait pas partie de cette quête</translation>
     </message>
@@ -3302,12 +3315,12 @@ Please save it or close it before renaming.</source>
         <translation>Script Lua</translation>
     </message>
     <message>
-        <location filename="../src/quest_files_model.cpp" line="589"/>
+        <location filename="../src/quest_files_model.cpp" line="529"/>
         <source>%1 (file not found)</source>
         <translation>%1 (fichier introuvable)</translation>
     </message>
     <message>
-        <location filename="../src/quest_files_model.cpp" line="594"/>
+        <location filename="../src/quest_files_model.cpp" line="534"/>
         <source>%1 (not in the quest)</source>
         <translation>%1 (non inclus dans la quête)</translation>
     </message>
@@ -5333,7 +5346,7 @@ Titre de la fenêtre. Vous devriez probablement mettre le titre de votre jeu ici
         <location filename="../src/widgets/tileset_editor.cpp" line="1258"/>
         <source>The tileset image was modified.
 Do you want to refresh the tileset?</source>
-        <translation type="unfinished">L&apos;image du tileset a été modifée.
+        <translation>L&apos;image du tileset a été modifée.
 Voulez-vous recharger l&apos;image ?</translation>
     </message>
 </context>


### PR DESCRIPTION
Add a open quest file dialog inspired by this one of Atom editor (Closes #154).

It take into account all suggestions that was made in the thread (regex, exact match and history).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/christopho/solarus-quest-editor/214)
<!-- Reviewable:end -->
