### PR TITLE
Correctly guess the assets directory for installed builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,8 +38,9 @@ set(CMAKE_CXX_FLAGS_DEBUG "-Wall -Werror -Wextra -pedantic ${CMAKE_CXX_FLAGS_DEB
 
 # Add defines for the install path and the build path to help guess the assets
 # location at runtime.
-add_definitions(-DSOLARUSEDITOR_INSTALL_PATH="${CMAKE_INSTALL_PREFIX}")
 add_definitions(-DSOLARUSEDITOR_SOURCE_PATH="${CMAKE_SOURCE_DIR}")
+add_definitions(-DSOLARUSEDITOR_BINDIR_PATH="${CMAKE_INSTALL_PREFIX}/${SOLARUS_INSTALL_BINDIR}")
+add_definitions(-DSOLARUSEDITOR_DATADIR_PATH="${CMAKE_INSTALL_PREFIX}/${SOLARUS_INSTALL_DATADIR}")
 
 # Find dependencies.
 set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" "${CMAKE_SOURCE_DIR}/cmake/modules/")

--- a/src/file_tools.cpp
+++ b/src/file_tools.cpp
@@ -42,8 +42,7 @@ namespace {
  * - The directory containing the executable.
  * - The source path (macro SOLARUSEDITOR_SOURCE_PATH)
  *   (useful for developer builds).
- * - The install path (macro SOLARUSEDITOR_INSTALL_PATH)
- *   followed by "share/solarus-quest-editor/".
+ * - The install path (macro SOLARUSEDITOR_DATADIR_PATH).
  */
 void initialize_assets() {
 
@@ -54,7 +53,7 @@ void initialize_assets() {
   potential_paths << executable_path + "/assets";
 
   // Try the source path if we are not running the installed executable.
-  bool running_installed_executable = (executable_path == SOLARUSEDITOR_INSTALL_PATH "/bin");
+  bool running_installed_executable = (executable_path == SOLARUSEDITOR_BINDIR_PATH);
 #ifdef SOLARUSEDITOR_SOURCE_PATH
   if (!running_installed_executable) {
     potential_paths << SOLARUSEDITOR_SOURCE_PATH "/assets";
@@ -62,9 +61,9 @@ void initialize_assets() {
 #endif
 
   // Try the install path if we are running the installed executable.
-#ifdef SOLARUSEDITOR_INSTALL_PATH
+#ifdef SOLARUSEDITOR_DATADIR_PATH
   if (running_installed_executable) {
-    potential_paths << SOLARUSEDITOR_INSTALL_PATH "/share/solarus-quest-editor/assets";
+    potential_paths << SOLARUSEDITOR_DATADIR_PATH;
   }
 #endif
 


### PR DESCRIPTION
When solarus-quest-editor is installed with `-DSOLARUS_INSTALL_BINDIR` or `-DSOLARUS_INSTALL_DATADIR` hard coded assumptions for the install and assets directories will fail. To avoid this add defines for `-DSOLARUSEDITOR_BINDIR_PATH` and `-DSOLARUSEDITOR_DATADIR_PATH` instead of `-SOLARUSEDITOR_INSTALL_PATH` and then remove the hardcoded paths in `src/file_tools.cpp`.