### PR TITLE
Change the shortcut to exit to Ctrl+Q.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,7 @@ ________________________________________
 
 * Tileset editor: allow to duplicate tile patterns (#188).
 * Tileset editor: allow to move several patterns at once (#171).
+* The shortcut to exit is now Ctrl+Q.
 
 _______________________________________
 

--- a/src/widgets/main_window.cpp
+++ b/src/widgets/main_window.cpp
@@ -161,7 +161,6 @@ MainWindow::MainWindow(QWidget* parent) :
   ui.action_new_quest->setShortcut(QKeySequence::New);
   ui.action_close->setShortcut(QKeySequence::Close);
   ui.action_save->setShortcut(QKeySequence::Save);
-  ui.action_exit->setShortcut(QKeySequence::Quit);
   undo_action->setShortcut(QKeySequence::Undo);
   redo_action->setShortcut(QKeySequence::Redo);
   ui.action_cut->setShortcut(QKeySequence::Cut);

--- a/src/widgets/main_window.ui
+++ b/src/widgets/main_window.ui
@@ -185,6 +185,9 @@
    <property name="text">
     <string>Exit</string>
    </property>
+   <property name="shortcut">
+    <string>Ctrl+Q</string>
+   </property>
   </action>
   <action name="action_run_quest">
    <property name="icon">


### PR DESCRIPTION
I find it more convenient to be able to exit with the keyboard than mouse so I suggest using `Ctrl+Q` since its a fairly standard keybind for closing GUI programs. Suggestions are of course welcome.